### PR TITLE
Update to solve a "(Unidentified Video Host)" error on "cizgifilmleri…

### DIFF
--- a/plugin.video.watchcartoononline/resolvers/_WatchCartoonOnline.py
+++ b/plugin.video.watchcartoononline/resolvers/_WatchCartoonOnline.py
@@ -61,7 +61,7 @@ def DoResolve(url):
         html  = theNet.http_POST(url, data).content.replace('\n', '').replace('\t', '')
 
         try:
-            match = re.compile('file: "(.+)",.+?image').search(html).group(1)             
+            match = re.compile('file: "([^"]+)"').search(html).group(1)             
         except Exception, e:
             match = re.compile('file=(.+?)&provider=http').search(html).group(1).split('file=', 1)[-1]
 


### PR DESCRIPTION
…zle" video files

It seems that lately, the response format changed for cizgifilmlerizle POST response
The image tag is before, not after.
So I propose this change line 64 to match the file name.