### PR TITLE
Do not remove the series name from the episode if it differs from the main series name

### DIFF
--- a/plugin.video.watchcartoononline/default.py
+++ b/plugin.video.watchcartoononline/default.py
@@ -155,7 +155,7 @@ def DoSeries(html):
             name  = re.compile('title="(.+?)"').search(item).group(1)    
             if name.startswith('Watch'):
                 name = name.split('Watch', 1)[-1].strip()
-            AddEpisode(name, url, image)
+            AddEpisode(title, name, url, image)
         except Exception, e:
             pass
 
@@ -303,12 +303,13 @@ def PlayVideo(_url, select):
         xbmcplugin.setResolvedUrl(int(sys.argv[1]), True, liz)
         
 
-def AddEpisode(name, url, image=None):
+def AddEpisode(seriesName, name, url, image=None):
     menu = []
     menu.append(('Download', 'XBMC.RunPlugin(%s?mode=%d&url=%s&title=%s)' % (sys.argv[0], DOWNLOAD, urllib.quote_plus(url), urllib.quote_plus(name))))
     if AUTOPLAY:
         menu.append(('Select video host', 'XBMC.RunPlugin(%s?mode=%d&url=%s)' % (sys.argv[0], HOST, urllib.quote_plus(url))))
-    AddDir(name, EPISODE, url, image=image, isFolder=False, menu=menu)
+    infoLabels = {'seriesName': seriesName}
+    AddDir(name, EPISODE, url, image=image, isFolder=False, infoLabels = infoLabels, menu=menu)
 
 
 def AddSeries(name, url):
@@ -372,7 +373,16 @@ def SetInfoData(name, infoLabels):
 
         # If an episode number is known then we can construct a better name
         if infoLabels['episode']:
-            infoLabels['title'] = infoLabels['season'] + 'x' + infoLabels['episode'] + ': ' + infoLabels['episodeName']
+            seriesPrefix = ''
+            # Check if the series name from the episode differs from the top series name (and is not contained)
+            if 'seriesName' in infoLabels and infoLabels['seriesName'] != infoLabels['episodeSeriesName'] and infoLabels['episodeSeriesName'] not in infoLabels['seriesName']:
+                seriesPrefix = infoLabels['episodeSeriesName'];
+                # In case the series name is contained in the episode series name then remove that part
+                seriesPrefix = seriesPrefix.replace(infoLabels['seriesName'], '')
+                # Add a dash
+                seriesPrefix = seriesPrefix + ' - '
+                
+            infoLabels['title'] = seriesPrefix + infoLabels['season'] + 'x' + infoLabels['episode'] + ': ' + infoLabels['episodeName']
 
         if meta.GetWatchedStatus(infoLabels) == True:
             infoLabels['overlay'] = 7

--- a/plugin.video.watchcartoononline/default.py
+++ b/plugin.video.watchcartoononline/default.py
@@ -132,7 +132,7 @@ def DoSection(url):
                         newName = newName.split('The ', 1)[-1]
                     sorted.append([newName, name, url])
                 elif mode == EPISODE:
-                    AddEpisode(name, url)
+                    AddEpisode('', name, url)
 
     sorted.sort()
     for item in sorted:

--- a/plugin.video.watchcartoononline/metadata.py
+++ b/plugin.video.watchcartoononline/metadata.py
@@ -78,7 +78,7 @@ class metadata:
     # At least the meta info dict must define the field "seriesName"
     def SetWatchedStatus(self, metaInfo, status):
         # If the seriesName is not known then we do not know where to put the information
-        if not metaInfo['seriesName']:
+        if not metaInfo['episodeSeriesName']:
             return
 
         try:

--- a/plugin.video.watchcartoononline/metadata.py
+++ b/plugin.video.watchcartoononline/metadata.py
@@ -67,8 +67,8 @@ class metadata:
         try:    metaInfo['season']      = seasonNum.strip()
         except: metaInfo['season']      = ''
 
-        try:    metaInfo['seriesName']  = seriesName.strip()
-        except: metaInfo['seriesName']  = ''
+        try:    metaInfo['episodeSeriesName']  = seriesName.strip()
+        except: metaInfo['episodeSeriesName']  = ''
 
         try:    metaInfo['episodeName'] = episodeName.strip()
         except: metaInfo['episodeName'] = ''
@@ -83,7 +83,7 @@ class metadata:
 
         try:
             # Generate the file system friendly name
-            fileName = os.path.join(self.cache_dir, 'watched_' + self.format_filename(metaInfo['seriesName']) + '.txt')
+            fileName = os.path.join(self.cache_dir, 'watched_' + self.format_filename(metaInfo['episodeSeriesName']) + '.txt')
             fileName = fileName.strip()
 
             # Generate the field name from the meta info
@@ -122,7 +122,7 @@ class metadata:
             return False
             
         # Generate the file system friendly name
-        fileName = os.path.join(self.cache_dir, 'watched_' + self.format_filename(metaInfo['seriesName']) + '.txt')
+        fileName = os.path.join(self.cache_dir, 'watched_' + self.format_filename(metaInfo['episodeSeriesName']) + '.txt')
         fileName = fileName.strip()
 
         # If the file does not exist then we have not watched this entry yet
@@ -132,8 +132,8 @@ class metadata:
         try:
             # Check if we still know this file, otherwise try to open it
             # This way, the content will be read only once for consecutive requests on the same series
-            if not metaInfo['seriesName'] == self.lastName:
-                self.lastName    = metaInfo['seriesName']
+            if not metaInfo['episodeSeriesName'] == self.lastName:
+                self.lastName    = metaInfo['episodeSeriesName']
                 self.lastContent = sfile.readlines(fileName)
                 
             # Generate a string for the episode


### PR DESCRIPTION
This fixes issue #29.
The infoLabels dict can now contain a field 'seriesName'. The series name generated by the metadata provider is now called 'episodeSeriesName'. If it differs from 'seriesName' and is not contained in 'seriesName' then it is prepended to the episode title. 
The part of 'seriesName' that is contained in 'episodeSeriesName' is removed.