### PR TITLE
Download images for series

### DIFF
--- a/plugin.video.watchcartoononline/default.py
+++ b/plugin.video.watchcartoononline/default.py
@@ -57,6 +57,8 @@ AUTOPLAY = ADDON.getSetting('AUTOPLAY') == 'true'
 import metadata
 meta = metadata.metadata()
 meta.SetDir(os.path.join(PROFILE ,'watched'))
+meta.SetImageDir(os.path.join(PROFILE, 'images'))
+
 
 
 def CheckVersion():
@@ -145,6 +147,8 @@ def DoSeries(html):
 
     html  = html.split('<!--CAT List FINISH-->', 1)[0]
     match = re.compile('<li>(.+?)</li>').findall(html)
+
+    image = meta.SetSeriesImage(title, image)
 
     for item in match:
         name = None
@@ -312,7 +316,7 @@ def AddEpisode(name, url, image=None):
 
 
 def AddSeries(name, url):
-    AddDir(name, SERIES, url)
+    AddDir(name, SERIES, url, meta.GetSeriesImage(name))
 
 
 def AddSection(name, image, url):

--- a/plugin.video.watchcartoononline/metadata.py
+++ b/plugin.video.watchcartoononline/metadata.py
@@ -53,6 +53,7 @@ class metadata:
     def SetSeriesImage(self, name, image):
         targetFile = self.GetSeriesImage(name)
         if not sfile.exists(targetFile):
+	    import urllib2
             req = urllib2.Request(image)
             req.add_header('User-Agent', utils.getUserAgent())
             response = urllib2.urlopen(req)

--- a/plugin.video.watchcartoononline/metadata.py
+++ b/plugin.video.watchcartoononline/metadata.py
@@ -42,7 +42,28 @@ class metadata:
         self.cache_dir = cache_dir
         if not sfile.exists(self.cache_dir):
             sfile.makedirs(self.cache_dir)
+
         
+    def SetImageDir(self, image_dir):
+        self.image_dir = image_dir
+        if not sfile.exists(self.image_dir):
+            sfile.makedirs(self.image_dir)
+
+
+    def SetSeriesImage(self, name, image):
+        targetFile = self.GetSeriesImage(name)
+        if not sfile.exists(targetFile):
+            req = urllib2.Request(image)
+            req.add_header('User-Agent', utils.getUserAgent())
+            response = urllib2.urlopen(req)
+            sfile.write(targetFile, response.read())
+            response.close()
+        return targetFile
+    
+    
+    def GetSeriesImage(self, name):
+        return os.path.join(self.image_dir, self.format_filename(name)+'.jpg')
+
         
     # Retrieve meta data from "name" and add it to the dict metaInfo
     # Names will be compatible to XBMC infoLabels

--- a/plugin.video.watchcartoononline/sfile.py
+++ b/plugin.video.watchcartoononline/sfile.py
@@ -60,6 +60,12 @@ def read(filename):
     f.close()
     return content
 
+    
+def write(filename, content):
+    f = file(filename, 'wb')
+    f.write(content)
+    f.close()
+
 
 def readlines(filename):
     lines = read(filename)

--- a/plugin.video.watchcartoononline/wco_utils.py
+++ b/plugin.video.watchcartoononline/wco_utils.py
@@ -69,6 +69,16 @@ def fixup(text):
     newText = newText.strip('/\\')
     return newText
 
+    
+def sloppyCompare(str1, str2):
+    import re
+
+    sloppyStr1 = re.sub(r'[\W\s_]', '', str1).lower()
+    sloppyStr2 = re.sub(r'[\W\s_]', '', str2).lower()
+    
+    return sloppyStr1 == sloppyStr2
+
+    
 
 def fileSystemSafe(text):
     import re


### PR DESCRIPTION
This patch downloads series images. Sadly, there is no way to get the series image outside of the series html page (since the image name does not rely to the series name or can somehow be deduced). 
Now, all series reference a local image (that - on purpose - might not exist yet). When the episodes for the series are shown the image is downloaded.
This is especially helpful when a series is added to favorites.
A typical scenario is: user looks for series, then adds it to favorites (image not downloaded yet) and THEN enters the series (image will be downloaded).
This is somewhat experimental...